### PR TITLE
Allow filter and multiple where parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 use PlanningCenterAPI\PlanningCenterAPI as PCO;
 
 // Get environment variables
-$dotenv = Dotenv\Dotenv::create(__DIR__);
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__);
 $dotenv->load();
 
 ```  

--- a/src/PlanningCenterAPI.php
+++ b/src/PlanningCenterAPI.php
@@ -277,7 +277,7 @@ class PlanningCenterAPI
                 break;
         }
 
-        $this->parameters['where'] = 'where[' . $field . ']' . $op . $value;
+        $this->parameters['where'][] = 'where[' . $field . ']' . $op . $value;
 
         return $this;
     }
@@ -318,6 +318,17 @@ class PlanningCenterAPI
     public function order($order)
     {
         $this->parameters['order'] = $order;
+
+        return $this;
+    }
+
+    /**
+     * Set the filters to be used
+     * @param $filter
+     * @return $this
+     */
+    public function filter($filter) {
+        $this->parameters['filter'] = $filter;
 
         return $this;
     }
@@ -707,7 +718,7 @@ class PlanningCenterAPI
         // Append second association if provided - optional
         $endpoint .= ($this->associations2) ? '/' . $this->associations2 : '';
 
-                // Append second association if provided - optional
+        // Append second association if provided - optional
         $endpoint .= ($this->id3) ? '/' . $this->id3 : '';
 
         // Handle URL parameters, if provided
@@ -736,7 +747,9 @@ class PlanningCenterAPI
                 // where is special and is constructed elsewhere
                 $params .= $key . '=' . $value . '&';
             } else {
-                $params .= $value . '&';
+                foreach ($value as $where) {
+                    $params .= $where . '&';
+                }
             }
         }
 


### PR DESCRIPTION
Though not mentioned in the API docs, the API explorer allows the use of `filter` parameters, so I added support for that.
Added ability to use multiple `where` parameters.

Also updated README to use `Dotenv\Dotenv::createUnsafeImmutable()` instead of `create` so that env variables would be readable by `getenv` [when using current vlucas/phpdotenv version](https://github.com/vlucas/phpdotenv#putenv-and-getenv)